### PR TITLE
fix create poet validation w.r.t supported langs

### DIFF
--- a/server/core/languages_handlers.go
+++ b/server/core/languages_handlers.go
@@ -9,20 +9,13 @@ import (
 )
 
 func (a *API) GetSupportedLanguages(rw web.ResponseWriter, req *web.Request) {
-	ctx, err := xaqt.NewContext(xaqt.GetCompilers())
+	languages, err := a.getSupportedLanguages()
 	if err != nil {
 		a.Error(err.Error())
 
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
 
 		return
-	}
-
-	// TODO (cw|9.25.2018) return more sophisticated data about languages including
-	// version and supported libraries...
-	languages := []string{}
-	for k, _ := range ctx.Languages() {
-		languages = append(languages, k)
 	}
 
 	languagesJSON, err := json.Marshal(languages)
@@ -36,4 +29,20 @@ func (a *API) GetSupportedLanguages(rw web.ResponseWriter, req *web.Request) {
 
 	rw.Header().Set("Content-Type", "application/json")
 	rw.Write(languagesJSON)
+}
+
+func (*API) getSupportedLanguages() ([]string, error) {
+	ctx, err := xaqt.NewContext(xaqt.GetCompilers())
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO (cw|9.25.2018) return more sophisticated data about languages including
+	// version and supported libraries...
+	languages := []string{}
+	for k, _ := range ctx.Languages() {
+		languages = append(languages, k)
+	}
+
+	return languages, nil
 }


### PR DESCRIPTION
Major Changes:
* implement `getSupportedLanguages` method on API struct for simply
  returning a slice of supported languages.
* use `getSupportedLanguages` in `CreatePoet` API method to hand to
  validator
* add returns for error cases in `CreatePoet` API method for when the
  poet is tested but does *not* successfully run and when the poet
  is *not* created successfully.

resolves issue #51 