### PR TITLE
HOT-FIX: 🐳-ignore-🐞

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+# "even though docker doesn't want you in its life, we still <3 you"
+#                                    -- {pipi_sauvage}
+
+# apparently if there are any files/dirs which the current user cannot
+# read that are within the directory in which you are running `docker build .`
+# dockere will throw an error. see https://github.com/moby/moby/issues/34711
+# therefore, we must add the dev data mount point to this file s.t. its ignored
+.dev-data


### PR DESCRIPTION
# Overview
* when deploy scripts are triggered, `docker build ...` is run to build the prod image.
* the tests spin up a dev instance of the app to test against it which creates a `.dev-data` directory in which the test database is mounted.
* since docker build throws errors when there is **any** file/dir whic is unreadable by the current user in the same directory as your dockerfile, it will error (see [this](https://github.com/moby/moby/issues/3471134711)).
* since the `.dev-data` has a mount point for the dev docker database in it, it is unreadable by the current user...so

# Solution
* add `.dockerignore` and ignore the `.dev-data` directory